### PR TITLE
Add context class to input

### DIFF
--- a/src/VueFormulateDatepicker.vue
+++ b/src/VueFormulateDatepicker.vue
@@ -1,6 +1,7 @@
 <template>
   <Datepicker
     :class="`formulate-input-element formulate-input-element--${context.type}`"
+    :input-class="context.attributes.class"
     :data-type="context.type"
     v-model="date"
     :options="context.options"


### PR DESCRIPTION
This adds the current context class to the input to support global theming of vue-formulate.  

For example with bootstrap:

```ts
Vue.use(
        VueFormulate,
        {
            classes: {
                outer: "form-group",
                input: "form-control",
                wrapperHasErrors: "is-invalid",
                inputHasErrors: "is-invalid",
                help: "form-text text-muted",
                errors: "list-unstyled invalid-feedback",
                label: "form-label"
            },
            plugins: [VueFormulateDatepickerPlugin]
        });
```

This will add the class `form-control` to the datepicker input to style it inline with other inputs.  And it will add the `is-invalid` class when the input has validation errors.